### PR TITLE
Pull Request

### DIFF
--- a/init/init.oplus.rc
+++ b/init/init.oplus.rc
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 The LineageOS Project
+# Copyright (C) 2022-2024 The LineageOS Project
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -85,58 +85,6 @@ on property:sys.boot_completed=1
     # Display
     copy /vendor/etc/Oppo_QC_LTM_Commercial_2020_01_03.pfm /mnt/vendor/persist/data/pfm/licenses/1000-1000-no-exp-958228818.pfm
     chown system system /mnt/vendor/persist/data/pfm/licenses/1000-1000-no-exp-958228818.pfm
-
-on property:sys.usb.config=adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x2769
-
-on property:sys.usb.config=mass_storage && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idProduct 0x2768
-    write /config/usb_gadget/g1/idVendor 0x22D9
-
-on property:sys.usb.config=mtp && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x2764
-
-on property:sys.usb.config=mtp,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x2765
-
-on property:sys.usb.config=ptp && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x2771
-
-on property:sys.usb.config=ptp,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x2772
-
-on property:sys.usb.config=rndis,none && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x276A
-
-on property:sys.usb.config=rndis,serial_cdev,diag && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x2783
-
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=diag,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x276C
-
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=diag,diag_mdm,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x276E
-
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=mass_storage,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x2767
-
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=rndis,diag,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x2775
-
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=rndis,none,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idVendor 0x22D9
-    write /config/usb_gadget/g1/idProduct 0x2766
 
 service oplus-sh /odm/bin/init.oplus.sh
     user root

--- a/vendor.prop
+++ b/vendor.prop
@@ -238,13 +238,14 @@ persist.vendor.sensors.allow_non_default_discovery=true
 persist.vendor.sensors.sync_request=true
 
 # USB
+sys.usb.mtp.batchcancel=1
 vendor.usb.diag.func.name=diag
 vendor.usb.dpl.inst.name=dpl
 vendor.usb.qdss.inst.name=qdss
 vendor.usb.rmnet.func.name=gsi
 vendor.usb.rmnet.inst.name=rmnet
 vendor.usb.rndis.func.name=gsi
-vendor.usb.use_ffs_mtp=0
+vendor.usb.use_ffs_mtp=1
 vendor.usb.use_gadget_hal=1
 
 # USB String


### PR DESCRIPTION
This pull request includes updates to the `init` and `vendor` configurations for improved compatibility and functionality. The most significant changes involve the removal of USB configuration properties from the `init.oplus.rc` file and adjustments to USB-related properties in the `vendor.prop` file.

### Changes to USB Configuration:

* [`init/init.oplus.rc`](diffhunk://#diff-28e1765e48d6c4f0466a141493021346d2b863b88066760e3d972ed54f83d061L89-L140): Removed multiple `on property` handlers related to USB configurations, which included setting USB vendor and product IDs for various USB modes (e.g., ADB, MTP, PTP, RNDIS). These removals simplify the USB configuration logic.
* [`vendor.prop`](diffhunk://#diff-b4213ceaf8987b40d7eb56c119510ac7a0fdbf3c6a5334b96dfdcd145bcc76b1R241-R248): Updated USB-related properties by enabling `vendor.usb.use_ffs_mtp` (changed from `0` to `1`) and adding a new property, `sys.usb.mtp.batchcancel=1`, to enhance MTP functionality.

### General Updates:

* [`init/init.oplus.rc`](diffhunk://#diff-28e1765e48d6c4f0466a141493021346d2b863b88066760e3d972ed54f83d061L2-R2): Updated the copyright year to include 2024.